### PR TITLE
Plot specificity results against model size

### DIFF
--- a/experiments/e2e_analyze.py
+++ b/experiments/e2e_analyze.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import json
 from collections import defaultdict
@@ -363,7 +364,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dirs = [Path(d) for d in args.dirs]
 
-    for dir in dirs:
-        main_single(results_dir=dir)
+    for d in tqdm(dirs):
+        main_single(results_dir=d)
 
     main_multi(dirs)


### PR DESCRIPTION
This adapts the `e2e_analyze` script to produce plots showing performance against model size.

Specifically, we plot the drawdown in performance (when going from specificity to specificity+) versus models (gpt2-medium, xl, 6b). Parameter counts for these models happen to be roughly equi-spaced on a log axis.