### PR TITLE
Export confidence intervals

### DIFF
--- a/experiments/merge_confidence_interval_results.py
+++ b/experiments/merge_confidence_interval_results.py
@@ -3,7 +3,7 @@ Find all files in the results folder named {metric}_ci.csv or {metric}_ci+.csv,
 extract the values for "mean", "0.5%", and "99.5%",
 and merge them into csv files of this form:
 
-```
+```csv
 ,CounterFact,CounterFact+
 GPT-2 M,"0.0e+00 (0.0e+00, 0.0e+00)","0.0e+00 (0.0e+00, 0.0e+00)"
 FT-L,"1.4e-05 (1.3e-05, 1.4e-05)","1.4e-05 (1.3e-05, 1.4e-05)"
@@ -56,14 +56,37 @@ def main():
 
     # merge datasets into one dataframe
     for metric in METRICS:
-        df = pd.DataFrame()
+        df_csv = pd.DataFrame()
+        df_latex = pd.DataFrame()
         for col in ["CounterFact", "CounterFact+"]:
             format_strs = ('{:.1e}', '{:.1e}') if metric == "KL" else ('{:.2f}', '{:.3f}')
-            mean = stat_to_metric_dataset_to_series["mean"][(f"N{metric}", col)].map(format_strs[0].format)
-            lower = stat_to_metric_dataset_to_series["0.5%"][(f"N{metric}", col)].map(format_strs[1].format)
-            upper = stat_to_metric_dataset_to_series["99.5%"][(f"N{metric}", col)].map(format_strs[1].format)
-            df[col] = mean + " (" + lower + ", " + upper + ")"
-        df.to_csv(RESULTS_DIR / f"N{metric}_from_bootstrap.csv")
+            mean = stat_to_metric_dataset_to_series["mean"][(f"N{metric}", col)].dropna().map(format_strs[0].format)
+            lower = stat_to_metric_dataset_to_series["0.5%"][(f"N{metric}", col)].dropna().map(format_strs[1].format)
+            upper = stat_to_metric_dataset_to_series["99.5%"][(f"N{metric}", col)].dropna().map(format_strs[1].format)
+            df_csv[col] = mean + " (" + lower + ", " + upper + ")"
+            df_latex[col] = mean + " \confint{" + lower + "}{" + upper + "}"  # use with custom latex command \confint
+
+        df_csv.to_csv(RESULTS_DIR / f"N{metric}_from_bootstrap.csv")
+
+        # write latex table
+        with open(RESULTS_DIR / f"N{metric}_from_bootstrap.tex", "w") as f:
+            f.write(df_latex.to_latex(escape=False))
+
+        # reformat latex table for easier copy-pasting
+        with open(RESULTS_DIR / f"N{metric}_from_bootstrap.tex", "r") as f:
+            lines = f.readlines()
+        # drop lines delimiting the tabular environment
+        lines = [line for line in lines if not line.startswith("\\begin") and not line.startswith("\\end")]
+
+        # surround every line starting with "GPT" with \midrule
+        with open(RESULTS_DIR / f"N{metric}_from_bootstrap.tex", "w") as f:
+            f.write(lines[0])
+            for prev, next in zip(lines, lines[1:]):
+                if next.startswith("\\midrule"):
+                    continue
+                if next.startswith("GPT"):
+                    next = f"\\midrule\\midrule\n{next}\\midrule\n"
+                f.write(next)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
...for all results for easy copy-paste into a latex draft.

Main script is `merge_confidence_interval_results.py` which produces csv files and tex files. The tex files contain snippets of this form 
```latex
\toprule
{} &                  CounterFact &                 CounterFact+ \\
\midrule\midrule
GPT-2 M    &  0.75 \confint{0.749}{0.757} &  0.46 \confint{0.452}{0.463} \\
\midrule
FT-L       &  0.52 \confint{0.515}{0.524} &  0.21 \confint{0.209}{0.217} \\
ROME       &  0.72 \confint{0.718}{0.726} &  0.11 \confint{0.102}{0.108} \\
\midrule\midrule
GPT-2 XL   &  0.78 \confint{0.780}{0.788} &  0.52 \confint{0.519}{0.530} \\
\midrule
FT-L       &  0.71 \confint{0.702}{0.711} &  0.38 \confint{0.375}{0.385} \\
ROME       &  0.76 \confint{0.755}{0.763} &  0.14 \confint{0.135}{0.142} \\
MEMIT      &  0.77 \confint{0.770}{0.778} &  0.32 \confint{0.314}{0.324} \\
\midrule\midrule
GPT-J (6B) &  0.83 \confint{0.830}{0.839} &  0.63 \confint{0.628}{0.639} \\
\midrule
FT-L       &  0.79 \confint{0.786}{0.795} &  0.54 \confint{0.538}{0.550} \\
ROME       &  0.79 \confint{0.786}{0.796} &  0.33 \confint{0.323}{0.333} \\
MEMIT      &  0.82 \confint{0.811}{0.820} &  0.40 \confint{0.395}{0.407} \\
\bottomrule
```
This assumes a custom command `\confint` for typesetting the confidence intervals.

The only thing to be done manually is the bolding of the max values in every column in every block.